### PR TITLE
Allow custom font storage location

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,18 @@ The `wptt_get_webfont_styles` will - by default - download `.woff2` files. Howev
 ```php
 wptt_get_webfont_styles( 'https://fonts.googleapis.com/css2?family=Literata&display=swap', 'woff' );
 ```
+
+## Storing In A Custom Directory
+If you have the need to store font files in a custom directory you can pass a new path through to the `wptt_get_local_fonts_directory_path` filter. The value passed should not include the end folder. If you want to rename the end folder used you can pass a new name through to the `wptt_get_local_fonts_directory_folder` filter. Be sure you add these filters **BEFORE** the file containing the `WPTT_WebFont_Loader` class is called.
+
+```php
+// set a new path where the fonts folder will exist/be created.
+add_filter( 'wptt_get_local_fonts_directory_path', function() {
+	return '/new/path/for/storage';
+});
+
+// set a new folder to save fonts in.
+add_filter( 'wptt_get_local_fonts_directory_folder' function() {
+	return 'new-fonts-folder';
+});
+```

--- a/wptt-webfont-loader.php
+++ b/wptt-webfont-loader.php
@@ -60,6 +60,27 @@ if ( ! class_exists( 'WPTT_WebFont_Loader' ) ) {
 		protected $fonts_directory_folder;
 
 		/**
+		 * Gets the local fonts directory from protected class property. It the
+		 * provate property is not set when this is called it passed a default
+		 * value through the `wptt_get_local_fonts_directory` filter to set it.
+		 *
+		 * @method get_local_fonts_directory
+		 * @since  1.1.0
+		 * @return string
+		 */
+		public function get_local_fonts_directory() {
+			if ( ! isset( $this->fonts_directory ) ) {
+				// The fonts_directory is not set. Set it passing through some
+				// filters to allow modification at runtime.
+				$this->fonts_directory_path   = (string) apply_filters( 'wptt_get_local_fonts_directory_path', WP_CONTENT_DIR );
+				$this->fonts_directory_folder = (string) apply_filters( 'wptt_get_local_fonts_directory_folder', 'fonts' );
+
+				$this->fonts_directory = wp_slash( $this->fonts_directory_path ) . $this->fonts_directory_folder;
+			}
+			return $this->fonts_directory;
+		}
+
+		/**
 		 * Get styles from URL.
 		 *
 		 * @access public

--- a/wptt-webfont-loader.php
+++ b/wptt-webfont-loader.php
@@ -27,6 +27,39 @@ if ( ! class_exists( 'WPTT_WebFont_Loader' ) ) {
 		public $font_format = 'woff2';
 
 		/**
+		 * The full path, including folder name, where the fonts are stored.
+		 *
+		 * @access protected
+		 *
+		 * @since 1.1.0
+		 *
+		 * @var string
+		 */
+		protected $fonts_directory;
+
+		/**
+		 * Holds the local fonts directory once it is set.
+		 *
+		 * @access protected
+		 *
+		 * @since 1.1.0
+		 *
+		 * @var string
+		 */
+		protected $fonts_directory_path;
+
+		/**
+		 * Holds the folder name where fonts are stored.
+		 *
+		 * @access protected
+		 *
+		 * @since 1.1.0
+		 *
+		 * @var string
+		 */
+		protected $fonts_directory_folder;
+
+		/**
 		 * Get styles from URL.
 		 *
 		 * @access public

--- a/wptt-webfont-loader.php
+++ b/wptt-webfont-loader.php
@@ -60,9 +60,10 @@ if ( ! class_exists( 'WPTT_WebFont_Loader' ) ) {
 		protected $fonts_directory_folder;
 
 		/**
-		 * Gets the local fonts directory from protected class property. It the
-		 * provate property is not set when this is called it passed a default
-		 * value through the `wptt_get_local_fonts_directory` filter to set it.
+		 * Gets the local fonts directory from protected class property. If the
+		 * property is not set when this is called it passes a default value
+		 * through filters for the `wptt_get_local_fonts_directory_path` & the
+		 * `wptt_get_local_fonts_directory_folder` to set it.
 		 *
 		 * @method get_local_fonts_directory
 		 * @since  1.1.0

--- a/wptt-webfont-loader.php
+++ b/wptt-webfont-loader.php
@@ -115,7 +115,7 @@ if ( ! class_exists( 'WPTT_WebFont_Loader' ) ) {
 
 			// Convert paths to URLs.
 			foreach ( $files as $remote => $local ) {
-				$files[ $remote ] = str_replace( WP_CONTENT_DIR, content_url(), $local );
+				$files[ $remote ] = str_replace( $this->fonts_directory_path, content_url(), $local );
 			}
 
 			return str_replace(
@@ -142,14 +142,14 @@ if ( ! class_exists( 'WPTT_WebFont_Loader' ) ) {
 			$change     = false; // If in the end this is true, we need to update the cache option.
 
 			// If the fonts folder don't exist, create it.
-			if ( ! file_exists( WP_CONTENT_DIR . '/fonts' ) ) {
-				$this->get_filesystem()->mkdir( WP_CONTENT_DIR . '/fonts', FS_CHMOD_DIR );
+			if ( ! file_exists( $this->fonts_directory ) ) {
+				$this->get_filesystem()->mkdir( $this->fonts_directory, FS_CHMOD_DIR );
 			}
 
 			foreach ( $font_files as $font_family => $files ) {
 
 				// The folder path for this font-family.
-				$folder_path = WP_CONTENT_DIR . '/fonts/' . $font_family;
+				$folder_path = wp_slash( $this->fonts_directory ) . $font_family;
 
 				// If the folder doesn't exist, create it.
 				if ( ! file_exists( $folder_path ) ) {


### PR DESCRIPTION
This allows a custom path and folder name to be set via filters for the location to store the fonts. It uses `WP_CONTENT_DIR` as default path and `fonts` as the default folder name.

It is split into 2 filters (and 3 properties) because there is one piece of code existing in the package which does a `str_replace()` against the base path only (without replacing the folder name).

This code is **not yet fully tested** so don't merge it before testing :stuck_out_tongue: 

Fixes #1 