### PR TITLE
Fix: Typekit font urls coming with double quotes

### DIFF
--- a/wptt-webfont-loader.php
+++ b/wptt-webfont-loader.php
@@ -419,6 +419,7 @@ if ( ! class_exists( 'WPTT_WebFont_Loader' ) ) {
 
 					// Add the file URL.
 					$font_family_url = rtrim( ltrim( $match[0], 'url(' ), ')' );
+					$font_family_url = str_replace( '"', '', $font_family_url );
 
 					// Make sure to convert relative URLs to absolute.
 					$font_family_url = $this->get_absolute_path( $font_family_url );


### PR DESCRIPTION
 Typekit font URLs are coming wrapped in double quotes. When calling `download_url` function with an URL wrapped in double quotes, the result will be an error saying `A valid URL was not provided.`

In this PR, I just strip the double quotes from the URL. Since an URL can't actually have the `"` character in it, this PR shouldn't break anything else.

Fixes https://github.com/WPTT/webfont-loader/issues/15