### PR TITLE
fix: typekit font variations are not taken into consideration

### DIFF
--- a/wptt-webfont-loader.php
+++ b/wptt-webfont-loader.php
@@ -309,7 +309,7 @@ if ( ! class_exists( 'WPTT_WebFont_Loader' ) ) {
 					$filename  = basename( wp_parse_url( $url, PHP_URL_PATH ) );
 					$font_path = $folder_path . '/' . $filename;
 					/**
-					 * In typescript, the filename will always be the same. We also need to check for query vars in their URLs.
+					 * In Typekit, the filename will always be the same. We also need to check for query vars in their URLs.
 					 * They provide this font variation description that we can use https://github.com/typekit/fvd
 					 */
 					$queries = parse_url( $url, PHP_URL_QUERY );

--- a/wptt-webfont-loader.php
+++ b/wptt-webfont-loader.php
@@ -308,6 +308,18 @@ if ( ! class_exists( 'WPTT_WebFont_Loader' ) ) {
 					// Get the filename.
 					$filename  = basename( wp_parse_url( $url, PHP_URL_PATH ) );
 					$font_path = $folder_path . '/' . $filename;
+					/**
+					 * In typescript, the filename will always be the same. We also need to check for query vars in their URLs.
+					 * They provide this font variation description that we can use https://github.com/typekit/fvd
+					 */
+					$queries = parse_url( $url, PHP_URL_QUERY );
+					if ( ! empty( $queries ) ) {
+						$query_args = array();
+						parse_str( $queries, $query_args );
+						if ( array_key_exists( 'fvd', $query_args ) ) {
+							$font_path .= $query_args['fvd'];
+						}
+					}
 
 					// Check if the file already exists.
 					if ( file_exists( $font_path ) ) {
@@ -431,6 +443,7 @@ if ( ! class_exists( 'WPTT_WebFont_Loader' ) ) {
 				// We're using array_flip here instead of array_unique for improved performance.
 				$result[ $font_family ] = array_flip( array_flip( $result[ $font_family ] ) );
 			}
+
 			return $result;
 		}
 


### PR DESCRIPTION
This pull request will resolve the issue at https://github.com/WPTT/webfont-loader/issues/20 by searching for the "fvd" (font variation description) query variable in Typekit URLs and incorporating it into the file name, preventing overwriting of files.